### PR TITLE
Also publish wheels for python 3.14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-13, macos-14]
-        python: [cp39, cp310, cp311, cp312, cp313]
+        python: [cp39, cp310, cp311, cp312, cp313, cp314]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Hi @weinbe58 @mgbukov 

as documented in QuSpin#745 and Quspin#757 , qupin-extensions  does not publish wheels for python 3.13 and 3.14 (see https://pypi.org/project/quspin-extensions/#files ). 

one year ago, you merged a PR by me to add python 3.13 to the list of versions for which the wheels are built, but you never actually released those wheels.
This PR does the same, adding python 3.14 to the list, but once again I would like to ask you if you could not only merge this PR but also publish those wheels.

To release the new wheels, you have two options:
 - tag a new release on GitHub (`0.1.6.post1` in theory, as this is just a packaging upgrade, or `0.1.7` if you don't like it)
 - manually build the new wheels and upload them to the 0.1.6 release.

As I understand you have limited time, option 1 should really just take 2 minutes of your time, and would make it simpler for many students to use your software...

(I'm more than willing to contribute the time to do that myself and keep the release process up to date in the next years for this repo, if you wanted.)