### PR TITLE
Fix ComplexWarning for numpy>=2.0

### DIFF
--- a/src/quspin_extensions/basis/basis_general/_basis_general_core/source/general_basis_core.pyx
+++ b/src/quspin_extensions/basis/basis_general/_basis_general_core/source/general_basis_core.pyx
@@ -13,6 +13,13 @@ from libcpp.utility cimport pair
 from .general_basis_utils import uint32,uint64,uint256,uint1024,uint4096,uint16384
 
 
+try:
+    # NumPy >= 1.25 (and NumPy 2.x)
+    _ComplexWarning = _np.exceptions.ComplexWarning
+except Exception:
+    # NumPy <= 1.24: still available as np.ComplexWarning
+    _ComplexWarning = _np.ComplexWarning
+
 
 @cython.boundscheck(False)
 cdef get_proj_helper(general_basis_core[npy_uint] * B, npy_uint * basis, int nt, int nnt,
@@ -266,7 +273,7 @@ cdef class general_basis_core_wrap:
         if err.first == -1:
             raise ValueError("operator not recognized.")
         elif err.second == 1:
-            warnings.warn("attempting to use real type for complex matrix elements.",_np.ComplexWarning,stacklevel=4)
+            warnings.warn("attempting to use real type for complex matrix elements.",_ComplexWarning,stacklevel=4)
         elif err.first != 0:
             raise RuntimeError("user defined error code: {}".format(err.first))
  


### PR DESCRIPTION
`np.ComplexWarning` is deprecated in `numpy>=2.0`, so using it will raise an error. This error has been reported several times by quspin users https://github.com/QuSpin/QuSpin/issues/749, https://github.com/QuSpin/QuSpin/discussions/759. The following code reproduces this bug when `numpy>=2.0` is installed.

```python
from quspin.basis import spin_basis_general  # spin basis constructor
from quspin.operators import hamiltonian  # hamiltonian constructor
import numpy as np  # general math functions

#
###### define model parameters ######
J = 1.0  # spin-spin interaction
g = 0.5  # magnetic field strength
Lx, Ly = 4, 4  # linear dimension of 2d lattice
N_2d = Lx * Ly  # number of sites
#
###### setting up user-defined symmetry transformations for 2d lattice ######
s = np.arange(N_2d)  # sites [0,1,2,....]
x = s % Lx  # x positions for sites
y = s // Lx  # y positions for sites
T_x = (x + 1) % Lx + Lx * y  # translation along x-direction
T_y = x + Lx * ((y + 1) % Ly)  # translation along y-direction
#
###### setting up bases ######
basis_2d = spin_basis_general(
    N_2d,
    kxblock=(T_x, 1),
    kyblock=(T_y, 1),
)
#
###### setting up hamiltonian ######
# setting up site-coupling lists
Jzz = [[J, i, T_x[i]] for i in range(N_2d)] + [[J, i, T_y[i]] for i in range(N_2d)]
gx = [[g, i] for i in range(N_2d)]
#
static = [["zz", Jzz], ["x", gx]]
# build hamiltonian
H = hamiltonian(static, [], basis=basis_2d, dtype=np.float64)
# diagonalise H
E = H.eigvalsh()
```

The revised program uses `np.exceptions.ComplexWarning` in `numpy>=1.25` and `np.ComplexWarning` in older versions.