### PR TITLE
fix: bundle libomp into macOS wheels — breaks import when upgrading to quspin 1.0.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ repair-wheel-command = "auditwheel repair -w {dest_dir} {wheel}"
 
 [tool.cibuildwheel.macos]
 archs = ["native"]
-repair-wheel-command = "delocate-wheel --exclude libomp --require-archs {delocate_archs} -w {dest_dir} -v {wheel}"
+repair-wheel-command = "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}"
 
 
 [tool.cibuildwheel.windows]


### PR DESCRIPTION
**Triggered by upgrading to `quspin` 1.0.1**, which is the first release to declare `quspin-extensions` as a hard dependency. This pulls the 0.1.8 wheel automatically — and on macOS without `libomp` pre-installed, `import quspin` fails immediately.

## Problem

`quspin-extensions` 0.1.8 macOS wheels are not self-contained: `.so` extensions hardcode an rpath to the Homebrew `libomp` install (`/opt/homebrew/opt/libomp/lib`), but `libomp.dylib` is not bundled in the wheel. Users without a prior `brew install libomp` get a hard import failure:

```
ImportError: dlopen(...hcp_basis.cpython-312-darwin.so, 0x0002):
  Library not loaded: /opt/homebrew/opt/libomp/lib/libomp.dylib
  Reason: tried: '/opt/homebrew/opt/libomp/lib/libomp.dylib' (no such file)
```

**Why this surfaces with `quspin` 1.0.1:** 1.0.1 is the first release to declare `quspin-extensions` as a hard dependency — upgrading from 1.0.0 → 1.0.1 now pulls the broken wheel automatically, making `import quspin` fail completely on any machine without `libomp` pre-installed.

## Root cause

`pyproject.toml` passes `--exclude libomp` to `delocate-wheel`, preventing `libomp.dylib` from being bundled:

```toml
[tool.cibuildwheel.macos]
repair-wheel-command = "delocate-wheel --exclude libomp --require-archs {delocate_archs} -w {dest_dir} -v {wheel}"
```

## Fix

Remove `--exclude libomp` so `delocate` bundles `libomp.dylib` into `.dylibs/` and rewrites load commands to `@loader_path/../.dylibs/libomp.dylib`:

```toml
[tool.cibuildwheel.macos]
repair-wheel-command = "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}"
```

The `brew install libomp` step in `build.yml` is still needed for compilation.

## Trade-off

`--exclude libomp` was originally added to avoid the `OMP: Error #15` double-init crash when two packages each bundle their own OMP runtime. Bundling is the right default here — a hard `ImportError` blocking all users is worse than a potential double-init warning that can be suppressed via `KMP_DUPLICATE_LIB_OK` if needed.

## Workaround (until merged)

```bash
brew install libomp
```